### PR TITLE
Improved performance of calculation

### DIFF
--- a/E7 Gear Optimizer/Hero.cs
+++ b/E7 Gear Optimizer/Hero.cs
@@ -33,6 +33,9 @@ namespace E7_Gear_Optimizer
         private Dictionary<Stats, float> currentStats;
         private Dictionary<Stats, float> AwakeningStats { get; set; }
 
+        //Cache of Enum.GetValues(typeof(Stats)). Used to iterate over Stats. Greatly increases performance.
+        private static Stats[] statsArrayGeneric = Enum.GetValues(typeof(Stats)).Cast<Stats>().ToArray();
+
         public Hero(string ID, string name, List<Item> gear, Item artifact, int lvl, int awakening)
         {
             this.ID = ID;
@@ -201,7 +204,7 @@ namespace E7_Gear_Optimizer
         public Dictionary<Stats, float> calcStats()
         {
             Dictionary<Stats, float> itemStats = new Dictionary<Stats, float>();
-            foreach (Stats s in Enum.GetValues(typeof(Stats)))
+            foreach (Stats s in statsArrayGeneric)
             {
                 itemStats[s] = 0;
             }
@@ -244,7 +247,7 @@ namespace E7_Gear_Optimizer
         public Dictionary<Stats, float> calcStatsWithoutGear(float critbonus)
         {
             Dictionary<Stats, float> stats = new Dictionary<Stats, float>();
-            foreach (Stats s in Enum.GetValues(typeof(Stats)))
+            foreach (Stats s in statsArrayGeneric)
             {
                 stats[s] = 0;
             }
@@ -264,7 +267,7 @@ namespace E7_Gear_Optimizer
         {
             List<Set> activeSets = this.activeSets();
             Dictionary<Stats, float> stats = new Dictionary<Stats, float>();
-            foreach (Stats s in Enum.GetValues(typeof(Stats)))
+            foreach (Stats s in statsArrayGeneric)
             {
                 stats[s] = 0;
             }
@@ -307,7 +310,7 @@ namespace E7_Gear_Optimizer
         public Dictionary<Stats, float> setBonusStats(List<Set> activeSets)
         {
             Dictionary<Stats, float> stats = new Dictionary<Stats, float>();
-            foreach (Stats s in Enum.GetValues(typeof(Stats)))
+            foreach (Stats s in statsArrayGeneric)
             {
                 stats[s] = 0;
             }

--- a/E7 Gear Optimizer/Util.cs
+++ b/E7 Gear Optimizer/Util.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
+using System.Linq;
 using System.Net;
 
 namespace E7_Gear_Optimizer
@@ -106,6 +107,9 @@ namespace E7_Gear_Optimizer
             [ItemType.Boots] = new List<Stats>() { Stats.Crit, Stats.CritDmg, Stats.DEF, Stats.DEFPercent, Stats.EFF, Stats.HP, Stats.HPPercent, Stats.RES, Stats.SPD, Stats.ATK, Stats.ATKPercent }
         };
 
+        //Cache of Enum.GetValues(typeof(Set)). Used to iterate over sets. Greatly increases performance.
+        private static Set[] setsArrayGeneric = Enum.GetValues(typeof(Set)).Cast<Set>().ToArray();
+
         public static Bitmap ResizeImage(Image image, int width, int height)
         {
             var destRect = new Rectangle(0, 0, width, height);
@@ -173,7 +177,7 @@ namespace E7_Gear_Optimizer
         {
             List<Set> activeSets = new List<Set>();
             Dictionary<Set, int> setCounter = new Dictionary<Set, int>();
-            foreach (Set s in Enum.GetValues(typeof(Set)))
+            foreach (Set s in setsArrayGeneric)
             {
                 setCounter[s] = 0;
             }
@@ -181,7 +185,7 @@ namespace E7_Gear_Optimizer
             {
                 setCounter[item.Set] += 1;
             }
-            foreach (Set set in Enum.GetValues(typeof(Set)))
+            foreach (Set set in setsArrayGeneric)
             {
                 if (Util.fourPieceSets.Contains(set) && setCounter[set] / 4 > 0)
                 {


### PR DESCRIPTION
Cached results of frequently used Enum.GetValues() calls as iterations over resulted non-generic Array was very expensive.
Calculation is now about four times faster.