### PR TITLE
Check for a new release without Updater.exe

### DIFF
--- a/E7 Gear Optimizer/App.config
+++ b/E7 Gear Optimizer/App.config
@@ -12,6 +12,7 @@
     <add key="ApiUrl" value="http://epicsevendb-apiserver.herokuapp.com/api" />
     <add key="AssetUrl" value="http://assets.epicsevendb.com" />
     <add key="GitHubUrl" value="https://github.com/Zarroc2762/E7-Gear-Optimizer/releases"/>
+    <add key="GitHubApiUrl" value="https://api.github.com/repos/Zarroc2762/E7-Gear-Optimizer/releases/latest"/>
     <add key="Version" value="2.0.2.0"/>
     <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>

--- a/E7 Gear Optimizer/Main.Designer.cs
+++ b/E7 Gear Optimizer/Main.Designer.cs
@@ -147,6 +147,7 @@
             this.b_EditItem = new System.Windows.Forms.Button();
             this.b_NewItem = new System.Windows.Forms.Button();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.l_Status = new System.Windows.Forms.Label();
             this.l_ImportResults = new System.Windows.Forms.Label();
             this.b_ClearCache = new System.Windows.Forms.Button();
             this.cb_CacheWeb = new System.Windows.Forms.CheckBox();
@@ -1878,6 +1879,7 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.l_Status);
             this.tabPage1.Controls.Add(this.l_ImportResults);
             this.tabPage1.Controls.Add(this.b_ClearCache);
             this.tabPage1.Controls.Add(this.cb_CacheWeb);
@@ -1895,6 +1897,14 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // l_Status
+            // 
+            this.l_Status.AutoSize = true;
+            this.l_Status.Location = new System.Drawing.Point(6, 722);
+            this.l_Status.Name = "l_Status";
+            this.l_Status.Size = new System.Drawing.Size(0, 13);
+            this.l_Status.TabIndex = 12;
             // 
             // l_ImportResults
             // 
@@ -6430,6 +6440,7 @@
         private System.Windows.Forms.Label label35;
         private System.Windows.Forms.NumericUpDown nud_EnemyDef;
         private System.Windows.Forms.Label lbl_Sorting;
+        private System.Windows.Forms.Label l_Status;
     }
 }
 

--- a/E7 Gear Optimizer/Main.cs
+++ b/E7 Gear Optimizer/Main.cs
@@ -68,19 +68,19 @@ namespace E7_Gear_Optimizer
             var task = Util.GetLatestVerion();
             task.ContinueWith((ver) =>
             {
-                if (task.IsFaulted)
-                {
-                    l_Status.ForeColor = Color.Red;
-                    l_Status.Text = "Error checking for updates";
-                    return;
-                }
-                if (string.IsNullOrEmpty(ver.Result))
-                {
-                    l_Status.Text = "No updates available";
-                    return;
-                }
                 this.Invoke((Action)delegate
                 {
+                    if (task.IsFaulted)
+                    {
+                        l_Status.ForeColor = Color.Red;
+                        l_Status.Text = "Error checking for updates";
+                        return;
+                    }
+                    if (string.IsNullOrEmpty(ver.Result))
+                    {
+                        l_Status.Text = "No updates available";
+                        return;
+                    }
                     if (MessageBox.Show(this, $"New version {ver.Result} of the application is available." + Environment.NewLine + "Do you want to update now?",
                     "Update available", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                     {

--- a/E7 Gear Optimizer/Main.cs
+++ b/E7 Gear Optimizer/Main.cs
@@ -65,23 +65,35 @@ namespace E7_Gear_Optimizer
         public Main()
         {
             InitializeComponent();
+            Util.GetLatestVerion().ContinueWith((ver) =>
+            {
+                if (string.IsNullOrEmpty(ver.Result))
+                {
+                    return;
+                }
+                this.Invoke((Action)delegate
+                {
+                    if (MessageBox.Show(this, $"New version {ver.Result} of the application is available." + Environment.NewLine + "Do you want to update now?",
+                    "Update available", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                    {
+                        try
+                        {
+                            Process.Start("E7 Optimizer Updater.exe");
+                            Application.Exit();
+                        }
+                        catch
+                        {
+                            MessageBox.Show(this, "Could not find E7 Optimizer Updater.exe", "Could not find E7 Optimizer Updater.exe", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        }
+                    }
+                });
+            });
             ServicePointManager.Expect100Continue = true;
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
                    | SecurityProtocolType.Tls11
                    | SecurityProtocolType.Tls12
                    | SecurityProtocolType.Ssl3;
             Icon = Icon.FromHandle(Util.ResizeImage(Properties.Resources.bookmark, 19,18).GetHicon());
-            if (args.Length == 1)
-            {
-                try
-                {
-                    Process.Start("E7 Optimizer Updater.exe");
-                }
-                catch
-                {
-                    MessageBox.Show("Could not find E7 optimizer Updater.exe");
-                }
-            }
             if (Properties.Settings.Default.UseCache)
             {
                 Directory.CreateDirectory(Properties.Settings.Default.CacheDirectory);
@@ -2349,11 +2361,7 @@ namespace E7_Gear_Optimizer
 
         private void Main_Shown(object sender, EventArgs e)
         {
-            if (args.Length == 1 && File.Exists("E7 Optimizer Updater.exe"))
-            {
-                Application.Exit();
-            }
-            else if (Application.ProductVersion != Util.ver)
+            if (Application.ProductVersion != Util.ver)
             {
                 updated updated = new updated();
                 updated.ShowDialog();

--- a/E7 Gear Optimizer/Main.cs
+++ b/E7 Gear Optimizer/Main.cs
@@ -2067,6 +2067,8 @@ namespace E7_Gear_Optimizer
                 JObject json = createJson();
                 File.WriteAllText(sfd_export.FileName, json.ToString());
                 setLastUsedFileName(sfd_export.FileName, false);
+                l_ImportResults.Text = $"Successfully exported {data.Heroes.Count} heroes and {data.Items.Count} items to {sfd_export.FileName}";
+                l_ImportResults.ForeColor = Color.Green;
             }
         }
         

--- a/E7 Gear Optimizer/Main.cs
+++ b/E7 Gear Optimizer/Main.cs
@@ -65,10 +65,18 @@ namespace E7_Gear_Optimizer
         public Main()
         {
             InitializeComponent();
-            Util.GetLatestVerion().ContinueWith((ver) =>
+            var task = Util.GetLatestVerion();
+            task.ContinueWith((ver) =>
             {
+                if (task.IsFaulted)
+                {
+                    l_Status.ForeColor = Color.Red;
+                    l_Status.Text = "Error checking for updates";
+                    return;
+                }
                 if (string.IsNullOrEmpty(ver.Result))
                 {
+                    l_Status.Text = "No updates available";
                     return;
                 }
                 this.Invoke((Action)delegate
@@ -83,7 +91,7 @@ namespace E7_Gear_Optimizer
                         }
                         catch
                         {
-                            MessageBox.Show(this, "Could not find E7 Optimizer Updater.exe", "Could not find E7 Optimizer Updater.exe", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            MessageBox.Show(this, "Could not find E7 Optimizer Updater.exe", "Update error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         }
                     }
                 });

--- a/E7 Gear Optimizer/Util.cs
+++ b/E7 Gear Optimizer/Util.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace E7_Gear_Optimizer
 {
@@ -91,6 +94,7 @@ namespace E7_Gear_Optimizer
         public static string ApiUrl = System.Configuration.ConfigurationManager.AppSettings["ApiUrl"];
         public static string AssetUrl = System.Configuration.ConfigurationManager.AppSettings["AssetUrl"];
         public static string GitHubUrl = System.Configuration.ConfigurationManager.AppSettings["GitHubUrl"];
+        public static string GitHubApiUrl = System.Configuration.ConfigurationManager.AppSettings["GitHubApiUrl"];
         public static string ver = System.Configuration.ConfigurationManager.AppSettings["Version"];
         public static Bitmap error = Properties.Resources.error;
         public static Bitmap star = Properties.Resources.star;
@@ -272,6 +276,38 @@ namespace E7_Gear_Optimizer
         public static string toAPIUrl(string str)
         {
             return str.ToLower().Replace('&', ' ').Replace("   ", " ").Replace(' ', '-');
+        }
+
+        /// <summary>
+        /// Checks the latest release version of the app on the GitHub server
+        /// </summary>
+        /// <returns></returns>
+        public static async Task<string> GetLatestVerion()
+        {
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
+                   | SecurityProtocolType.Tls11
+                   | SecurityProtocolType.Tls12
+                   | SecurityProtocolType.Ssl3;
+            WebClient client = new WebClient();
+            client.Headers.Add(HttpRequestHeader.UserAgent, "E7 Optimizer Updater");
+            string json = "";
+            string latestver = "0";
+            int count = 0;
+            json = await client.DownloadStringTaskAsync(!string.IsNullOrEmpty(GitHubApiUrl) ? GitHubApiUrl : "https://api.github.com/repos/Zarroc2762/E7-Gear-Optimizer/releases/latest");
+            string newVer = latestver = JObject.Parse(json).Value<string>("tag_name").Replace("v", "");
+            count = latestver.Count(x => x == '.');
+            if (count == 1)
+            {
+                latestver += ".0.0";
+            }
+            else if (count == 2)
+            {
+                latestver += ".0";
+            }
+            latestver = latestver.Replace(".", "");
+            string ver = Application.ProductVersion.Replace(".", "");
+            return int.Parse(latestver) > int.Parse(ver) ? newVer : null;
         }
     }
 }


### PR DESCRIPTION
There is an issue that when the cache is enabled JSON is loaded twice - before the Updater and after. Also the black console window of the Updater is little annoying.
So I've took the version check code from the Updater and added it to the Util class.
What do you think?