### PR TITLE
Fix WSS calculation to include flat stats

### DIFF
--- a/E7 Gear Optimizer/Item.cs
+++ b/E7 Gear Optimizer/Item.cs
@@ -89,11 +89,11 @@ namespace E7_Gear_Optimizer
 
         public float WSS { get => wss; }
 
-        private const float wssMultiplier = 2f / 3f;
+        private const float wssMultiplier = 1f / 72f;
 
         public void calcWSS()
         {
-            wss = 0;
+            wss = 0f;
             foreach (Stat s in subStats)
             {
                 switch (s.Name)
@@ -103,16 +103,25 @@ namespace E7_Gear_Optimizer
                     case Stats.HPPercent:
                     case Stats.EFF:
                     case Stats.RES:
-                        wss += 100 * s.Value / 48;
+                        wss += 100f * s.Value;
                         break;
                     case Stats.Crit:
-                        wss += 100 * s.Value / 30;
+                        wss += 100f * s.Value * 8f / 5f;
                         break;
                     case Stats.CritDmg:
-                        wss += 100 * s.Value / 42;
+                        wss += 100f * s.Value * 8f / 7f;
                         break;
                     case Stats.SPD:
-                        wss += s.Value / 24;
+                        wss += s.Value * 8f / 4f;
+                        break;
+                    case Stats.ATK:
+                        wss += 100f * s.Value / 900f;
+                        break;
+                    case Stats.HP:
+                        wss += 100f * s.Value / 5000f;
+                        break;
+                    case Stats.DEF:
+                        wss += 100f * s.Value / 500f;
                         break;
                     default:
                         break;


### PR DESCRIPTION
I fixed the WSS calculation to be more transparent about how it actually works and included a somewhat generous base stat estimate for converting flat stats to percentage stats and then using them in the standard way in the WSS calc. I tested this build locally and the calculation works.

I should note that I changed all the values to floats to ensure that there wasn't errant rounding, but feel free to remove some of those changes if it impacts performance.